### PR TITLE
#7 property 에서 deny IP load 시 공간복잡도 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Log file
 *.log
+/logs/
 
 # BlueJ files
 *.ctxt
@@ -48,3 +49,6 @@ hs_err_pid*
 /dist/
 /nbdist/
 /.nb-gradle/
+
+# test file
+random-ip-denies*.yml

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
             <version>3.9</version>
         </dependency>
         <dependency>
-            <groupId>commons-net</groupId>
-            <artifactId>commons-net</artifactId>
-            <version>3.6</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/wynnn/ipfilter/config/IpFilterConfiguration.java
+++ b/src/main/java/com/wynnn/ipfilter/config/IpFilterConfiguration.java
@@ -1,6 +1,7 @@
 package com.wynnn.ipfilter.config;
 
 import com.wynnn.ipfilter.model.Ipv4Subnet;
+import com.wynnn.ipfilter.utils.IpUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -9,8 +10,8 @@ import org.springframework.context.annotation.Configuration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 @Configuration
 @ConfigurationProperties(prefix = "ip-filter")
@@ -23,30 +24,29 @@ public class IpFilterConfiguration {
     public void setDeny(List<String> deny) {
         this.deny = Optional.ofNullable(deny)
                 .filter(denies -> denies.size() > 0)
-                .map(this::parseSubnet)
-                .map(this::removeNestedSubnet)
+                .map(this::parseNestedSubnet)
                 .orElse(new TreeMap<>());
         log.debug("> completed to set deny={}", this.deny);
     }
 
-    private TreeSet<Ipv4Subnet> parseSubnet(List<String> denyIps) {
-        TreeSet<Ipv4Subnet> treeSet = new TreeSet<>();
+    private TreeMap<Long, Ipv4Subnet> parseNestedSubnet(List<String> denyIps) {
+        TreeMap<Long, Ipv4Subnet> denyRules = new TreeMap<>();
         for (String denyIp : denyIps) {
             try {
-                treeSet.add(new Ipv4Subnet(denyIp));
+                Ipv4Subnet subnet = new Ipv4Subnet(denyIp);
+                Map.Entry<Long, Ipv4Subnet> floorEntry = denyRules.floorEntry(subnet.getIpLong());
+                if (floorEntry == null) {
+                    denyRules.put(subnet.getIpLong(), subnet);
+                } else if (floorEntry.getValue().isNestedSubnet(subnet)) { // if new subnet is nested then skip
+                    continue;
+                } else {
+                    SortedMap<Long, Ipv4Subnet> nested = denyRules.subMap(subnet.getIpLong(), true,
+                            IpUtils.ipToLong(subnet.getSubnet().getInfo().getHighAddress()), true);
+                    nested.keySet().forEach(denyRules::remove);
+                    denyRules.put(subnet.getIpLong(), subnet);
+                }
             } catch (Exception e) {
                 log.info("> cannot parse IP because invalid format, IP={}", denyIp, e);
-            }
-        }
-        return treeSet;
-    }
-
-    private TreeMap<Long, Ipv4Subnet> removeNestedSubnet(TreeSet<Ipv4Subnet> denySubnet) {
-        TreeMap<Long, Ipv4Subnet> denyRules = new TreeMap<>();
-        for (Ipv4Subnet subnet : denySubnet) {
-            Map.Entry<Long, Ipv4Subnet> entry = denyRules.floorEntry(subnet.getIpLong());
-            if (entry == null || !entry.getValue().getSubnet().getInfo().isInRange(subnet.getSubnet().getInfo().getAddress())) {
-                denyRules.put(subnet.getIpLong(), subnet);
             }
         }
         return denyRules;

--- a/src/main/java/com/wynnn/ipfilter/model/Ipv4Subnet.java
+++ b/src/main/java/com/wynnn/ipfilter/model/Ipv4Subnet.java
@@ -2,54 +2,46 @@ package com.wynnn.ipfilter.model;
 
 import com.wynnn.ipfilter.utils.IpUtils;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.net.util.SubnetUtils;
+import org.apache.commons.lang3.StringUtils;
 
+@ToString
 @Getter
 @Slf4j
 public class Ipv4Subnet implements Comparable<Ipv4Subnet> {
+    private long startIpLong;
+    private long endIpLong;
     private long ipLong;
     private int cidr;
-    private SubnetUtils subnet;
 
     public Ipv4Subnet(String ipAddress) throws IllegalArgumentException {
-        try {
-            IpUtils.convert(ipAddress)
-                    .flatMap(subnet -> IpUtils.convert(subnet.getInfo().getLowAddress(), subnet.getInfo().getNetmask()))
-                    .ifPresent(subnetWithFirstIp -> {
-                        subnet = subnetWithFirstIp;
-                        setIpLong(subnetWithFirstIp.getInfo().getAddress());
-                        setCidr(subnetWithFirstIp.getInfo().getCidrSignature());
-                    });
-        } catch (IllegalArgumentException e) {
-            log.debug("> cannot parse IP because invalid format, IP={}", ipAddress, e);
-            throw e;
+        if (StringUtils.isBlank(ipAddress)) {
+            throw new IllegalArgumentException(String.format("Cannot parse IP=%s because blank", ipAddress));
         }
-    }
-
-    private void setIpLong(String ipAddress) {
-        ipLong = IpUtils.ipToLong(ipAddress);
-    }
-
-    private void setCidr(String ipAddrWithCidrNotation) {
-        String[] cidrStr = ipAddrWithCidrNotation.split("/");
-        cidr = Integer.parseInt(cidrStr[cidrStr.length - 1]);
+        if (!IpUtils.CIDR_PATTERN.matcher(ipAddress).matches()) {
+            throw new IllegalArgumentException(String.format("Cannot parse IP=%s because invalid format", ipAddress));
+        }
+        String[] rawIp = ipAddress.split("/");
+        ipLong = IpUtils.ipToLong(rawIp[0]);
+        cidr = rawIp.length == 1 ? 32 : Integer.parseInt(rawIp[1]);
+        startIpLong = IpUtils.calcStartIpInSubnet(ipLong, cidr);
+        endIpLong = IpUtils.calcEndIpInSubnet(ipLong, cidr);
     }
 
     public boolean isNestedSubnet(Ipv4Subnet other) {
-        return IpUtils.ipToLong(subnet.getInfo().getLowAddress()) <= IpUtils.ipToLong(other.getSubnet().getInfo().getLowAddress())
-                && IpUtils.ipToLong(subnet.getInfo().getHighAddress()) >= IpUtils.ipToLong(other.getSubnet().getInfo().getHighAddress());
+        return startIpLong <= other.getStartIpLong() && other.getEndIpLong() <= endIpLong;
+    }
+
+    public boolean isInRange(long ip) {
+        return startIpLong <= ip && ip <= endIpLong;
     }
 
     @Override
     public int compareTo(Ipv4Subnet other) {
-        if (ipLong == other.getIpLong()) { // if the first IPs in the subnet are the same, then sort by CIDR (in small order)
+        if (startIpLong == other.getStartIpLong()) { // if the first IPs in the subnet are the same, then sort by CIDR (in small order)
             return Integer.compare(cidr, other.getCidr());
         }
-        return Long.compare(ipLong, other.getIpLong()); // sort by IP (in small order)
-    }
-
-    public String toString() {
-        return "Ipv4Subnet(ipLong=" + this.getIpLong() + ", cidr=" + this.getCidr() + ", subnet=" + this.getSubnet().getInfo().getCidrSignature() + ")";
+        return Long.compare(startIpLong, other.getStartIpLong()); // sort by IP (in small order)
     }
 }

--- a/src/main/java/com/wynnn/ipfilter/model/Ipv4Subnet.java
+++ b/src/main/java/com/wynnn/ipfilter/model/Ipv4Subnet.java
@@ -36,6 +36,11 @@ public class Ipv4Subnet implements Comparable<Ipv4Subnet> {
         cidr = Integer.parseInt(cidrStr[cidrStr.length - 1]);
     }
 
+    public boolean isNestedSubnet(Ipv4Subnet other) {
+        return IpUtils.ipToLong(subnet.getInfo().getLowAddress()) <= IpUtils.ipToLong(other.getSubnet().getInfo().getLowAddress())
+                && IpUtils.ipToLong(subnet.getInfo().getHighAddress()) >= IpUtils.ipToLong(other.getSubnet().getInfo().getHighAddress());
+    }
+
     @Override
     public int compareTo(Ipv4Subnet other) {
         if (ipLong == other.getIpLong()) { // if the first IPs in the subnet are the same, then sort by CIDR (in small order)

--- a/src/main/java/com/wynnn/ipfilter/service/IpAuthenticationServiceImpl.java
+++ b/src/main/java/com/wynnn/ipfilter/service/IpAuthenticationServiceImpl.java
@@ -1,7 +1,6 @@
 package com.wynnn.ipfilter.service;
 
 import com.wynnn.ipfilter.config.IpFilterConfiguration;
-import com.wynnn.ipfilter.model.Ipv4Subnet;
 import com.wynnn.ipfilter.utils.IpUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,10 +18,10 @@ public class IpAuthenticationServiceImpl implements IpAuthenticationService {
 
     @Override
     public boolean hasAuth(String clientIp) {
-        boolean result = Optional.ofNullable(ipFilterConfiguration.getDeny().floorEntry(IpUtils.ipToLong(clientIp)))
+        long clientIpLong = IpUtils.ipToLong(clientIp);
+        boolean result = Optional.ofNullable(ipFilterConfiguration.getDeny().floorEntry(clientIpLong))
                 .map(Map.Entry::getValue)
-                .map(Ipv4Subnet::getSubnet)
-                .map(subnet -> !subnet.getInfo().isInRange(clientIp))
+                .map(subnet -> !subnet.isInRange(clientIpLong))
                 .orElse(true);
         log.debug("> hasAuth(clientIp={}): {}", clientIp, result);
         return result;

--- a/src/main/resources-release/logback-spring.xml
+++ b/src/main/resources-release/logback-spring.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_PATH}/logFile.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <!-- daily rollover -->
+      <fileNamePattern>/logs/logFile.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>100MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <!-- keep 180 days' worth of history -->
+      <maxHistory>180</maxHistory>
+    </rollingPolicy>
+
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%M.%L - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+    </layout>
+  </appender>
+
+  <springProperty name="ACTIVE_PROFILE" source="spring.profiles.active"/>
+  <property name="INCLUDE_CALLER_DATA" value="false"/>
+  <property name="QUEUE_SIZE" value="2048"/>
+  <property name="NEVER_BLOCK" value="true"/>
+  <property name="MAX_FLUSH_TIME" value="60000"/>
+
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+  </root>
+
+  <logger name="com.wynnn.ipfilter" level="INFO" additivity="false">
+    <appender-ref ref="FILE"/>
+    <appender-ref ref="STDOUT"/>
+  </logger>
+</configuration>

--- a/src/test/java/com/wynnn/ipfilter/common/TestUtil.java
+++ b/src/test/java/com/wynnn/ipfilter/common/TestUtil.java
@@ -3,7 +3,6 @@ package com.wynnn.ipfilter.common;
 import com.wynnn.ipfilter.config.IpFilterConfiguration;
 import com.wynnn.ipfilter.model.Ipv4Subnet;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.net.util.SubnetUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -86,6 +85,44 @@ public class TestUtil {
         returnVal.put(4261412865L, "254.0.0.1");
         returnVal.put(4294904330L, "255.255.10.10");
         returnVal.put(4294967295L, "255.255.255.255");
+        return returnVal;
+    }
+
+    /**
+     * dummy subnet pool
+     * @return  key=ip subnet string with cidr notation
+     *          value=subnet info
+     *          value[0]=ip address (long)
+     *          value[1]=ip address string without cidr notation
+     *          value[2]=cidr (number of bit)
+     *          value[3]=start ip (long)
+     *          value[4]=end ip (long)
+     */
+    public static Map<String, String[]> createDummySubnetPool() {
+        Map<String, String[]> returnVal = new HashMap<>();
+        returnVal.put("0.0.0.0/0", new String[]{"0", "0.0.0.0", "0", "0", "4294967295"});   // 0.0.0.0 ~ 255.255.255.255
+        returnVal.put("0.0.0.0/1", new String[]{"0", "0.0.0.0", "1", "0", "2147483647"});   // 0.0.0.0 ~ 127.255.255.255
+        returnVal.put("0.0.0.0/12", new String[]{"0", "0.0.0.0", "12", "0", "1048575"});    // 0.0.0.0 ~ 0.15.255.255
+        returnVal.put("0.0.0.0/32", new String[]{"0", "0.0.0.0", "32", "0", "0"});          // 0.0.0.0 ~ 0.0.0.0
+
+        returnVal.put("0.0.0.1/0", new String[]{"1", "0.0.0.1", "0", "0", "4294967295"});   // 0.0.0.0 ~ 255.255.255.255
+        returnVal.put("0.0.0.1/24", new String[]{"1", "0.0.0.1", "24", "0", "255"});        // 0.0.0.0 ~ 0.0.0.255
+        returnVal.put("0.0.0.1/32", new String[]{"1", "0.0.0.1", "32", "1", "1"});          // 0.0.0.1 ~ 0.0.0.1
+
+        returnVal.put("0.50.0.3/5", new String[]{"3276803", "0.50.0.3", "5", "0", "134217727"});        // 0.0.0.0 ~ 7.255.255.255
+        returnVal.put("0.50.0.3/6", new String[]{"3276803", "0.50.0.3", "6", "0", "67108863"});         // 0.0.0.0 ~ 3.255.255.255
+        returnVal.put("0.50.0.3/24", new String[]{"3276803", "0.50.0.3", "24", "3276800", "3277055"});  // 0.50.0.0 ~ 0.50.0.255
+        returnVal.put("0.50.0.3/32", new String[]{"3276803", "0.50.0.3", "32", "3276803", "3276803"});  // 0.50.0.3 ~ 0.50.0.3
+
+        returnVal.put("254.0.0.1/0", new String[]{"4261412865", "254.0.0.1", "0", "0", "4294967295"});           // 0.0.0.0 ~ 255.255.255.255
+        returnVal.put("254.0.0.1/12", new String[]{"4261412865", "254.0.0.1", "12", "4261412864", "4262461439"});// 254.0.0.0 ~ 254.15.255.255
+        returnVal.put("254.0.0.1/20", new String[]{"4261412865", "254.0.0.1", "20", "4261412864", "4261416959"});// 254.0.0.0 ~ 254.0.15.255
+        returnVal.put("254.0.0.1/32", new String[]{"4261412865", "254.0.0.1", "32", "4261412865", "4261412865"});// 254.0.0.1 ~ 254.0.0.1
+
+        returnVal.put("255.255.255.255/0", new String[]{"4294967295", "255.255.255.255", "0", "0", "4294967295"});// 0.0.0.0 ~ 255.255.255.255
+        returnVal.put("255.255.255.255/10", new String[]{"4294967295", "255.255.255.255", "10", "4290772992", "4294967295"});// 255.192.0.0 ~ 255.255.255.255
+        returnVal.put("255.255.255.255/27", new String[]{"4294967295", "255.255.255.255", "27", "4294967264", "4294967295"});// 255.255.255.224 ~ 255.255.255.255
+        returnVal.put("255.255.255.255/32", new String[]{"4294967295", "255.255.255.255", "32", "4294967295", "4294967295"});// 255.255.255.255 ~ 255.255.255.255
         return returnVal;
     }
 }

--- a/src/test/java/com/wynnn/ipfilter/utils/IpUtilsTest.java
+++ b/src/test/java/com/wynnn/ipfilter/utils/IpUtilsTest.java
@@ -1,12 +1,13 @@
 package com.wynnn.ipfilter.utils;
 
 import com.wynnn.ipfilter.common.TestUtil;
-import org.apache.commons.net.util.SubnetUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IpUtilsTest {
 
@@ -32,22 +33,16 @@ class IpUtilsTest {
     }
 
     @Test
-    void test_convert_invalid_ip_then_throw() {
-        assertThrows(IllegalArgumentException.class, () -> IpUtils.convert("-1"));
-        assertThrows(IllegalArgumentException.class, () -> IpUtils.convert("-1", "255.255.255.255"));
+    void test_calcStartIpInSubnet() {
+        for (Map.Entry<String, String[]> entry : TestUtil.createDummySubnetPool().entrySet()) {
+            assertEquals(Long.parseLong(entry.getValue()[3]), IpUtils.calcStartIpInSubnet(Long.parseLong(entry.getValue()[0]), Integer.parseInt(entry.getValue()[2])));
+        }
     }
 
     @Test
-    void test_convert_if_not_include_cidr_notation() {
-        String testIp = "10.0.0.200";
-        SubnetUtils subnet = IpUtils.convert(testIp).get();
-        assertAll(
-                "if ip not include cidr notation then estimate 32 bit, IP=" + testIp,
-                () -> assertEquals("255.255.255.255", subnet.getInfo().getNetmask()),
-                () -> assertEquals(testIp, subnet.getInfo().getAddress()),
-                () -> assertEquals(testIp+"/32", subnet.getInfo().getCidrSignature()),
-                () -> assertEquals(testIp, subnet.getInfo().getLowAddress()),
-                () -> assertEquals(testIp, subnet.getInfo().getHighAddress())
-        );
+    void test_calcEndIpInSubnet() {
+        for (Map.Entry<String, String[]> entry : TestUtil.createDummySubnetPool().entrySet()) {
+            assertEquals(Long.parseLong(entry.getValue()[4]), IpUtils.calcEndIpInSubnet(Long.parseLong(entry.getValue()[0]), Integer.parseInt(entry.getValue()[2])));
+        }
     }
 }


### PR DESCRIPTION
* 불필요한 로직 삭제
  - property load 시 subnet 의 sort 과정 삭제, 바로 treeMap 에 저장 (treeMap 자체가 sorted 이므로 sorting 할 필요 없음)
  - treeMap 으로 변환 시 과도하게 중첩 제거하는 부분 삭제
     - property 에 10.0.0.4/26와 10.0.0.0/24 가 존재할 경우 10.0.0.4/26 를 굳이 제거할 필요는 없음.
* common.net.SubnetUtils 의존성 제거하고 일부 IP 계산 함수 직접 구현
  - common.net.SubnetUtils 은 readable IP format 으로 output 을 산출하기에 불필요하게 ipAddress to int 변환이 반복됨
  - 직접 구현한 내용 : IP 와 CIDR bit 정보 input 시 해당 subnet 의 start IP 와 end IP 반환