### PR TITLE
#4 deny IP 등록 개수 제한 (3000만개)

### DIFF
--- a/src/main/java/com/wynnn/ipfilter/config/IpFilterConfiguration.java
+++ b/src/main/java/com/wynnn/ipfilter/config/IpFilterConfiguration.java
@@ -1,6 +1,7 @@
 package com.wynnn.ipfilter.config;
 
 import com.wynnn.ipfilter.model.Ipv4Subnet;
+import com.wynnn.ipfilter.utils.IpUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -13,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Configuration
 @ConfigurationProperties(prefix = "ip-filter")
@@ -21,34 +23,48 @@ import java.util.TreeMap;
 public class IpFilterConfiguration {
 
     private TreeMap<Long, Ipv4Subnet> deny;
+    private final int MAX_NUM_DENY_IP = 30000000; // max number of deny IPs. (30 million)
+    private final AtomicLong numDenyIps = new AtomicLong();
 
     public void setDeny(List<String> deny) {
+        numDenyIps.set(0);
         this.deny = Optional.ofNullable(deny)
                 .filter(denies -> denies.size() > 0)
                 .map(this::parseNestedSubnet)
                 .orElse(new TreeMap<>());
-        log.info("> completed to set deny={}", this.deny.size());
+        log.info("> completed to set deny={}", numDenyIps);
     }
 
     private TreeMap<Long, Ipv4Subnet> parseNestedSubnet(List<String> denyIps) {
         TreeMap<Long, Ipv4Subnet> denyRules = new TreeMap<>();
         for (String denyIp : denyIps) {
+            if (numDenyIps.get() > MAX_NUM_DENY_IP) {
+                log.warn("> exceed max number of deny IPs (current number of applied IP is={}) : The deny applied only until the previous rule of this={}. {} not applied.",
+                        numDenyIps.get(), denyIp, denyIp);
+                break;
+            }
             try {
                 Ipv4Subnet subnet = new Ipv4Subnet(denyIp);
                 Map.Entry<Long, Ipv4Subnet> floorEntry = denyRules.floorEntry(subnet.getStartIpLong());
                 if (floorEntry == null) {
+                    numDenyIps.addAndGet(IpUtils.NUM_SUBNET[subnet.getCidr()]);
                     denyRules.put(subnet.getStartIpLong(), subnet);
                 } else if (floorEntry.getValue().isNestedSubnet(subnet)) { // if new subnet is nested then skip
                     continue;
                 } else {
                     // remove nested subnet
                     new HashSet<>(Optional.ofNullable(denyRules.subMap(subnet.getStartIpLong(), false, subnet.getEndIpLong(), true))
-                            .map(SortedMap::keySet)
+                            .map(SortedMap::entrySet)
                             .orElse(Collections.emptySet()))
-                            .forEach(denyRules::remove);
+                            .forEach(nested -> {
+                                numDenyIps.addAndGet(-IpUtils.NUM_SUBNET[nested.getValue().getCidr()]);
+                                denyRules.remove(nested.getKey());
+                            });
                     if (floorEntry.getKey() == subnet.getStartIpLong()) {
+                        numDenyIps.addAndGet(IpUtils.NUM_SUBNET[subnet.getCidr()] - IpUtils.NUM_SUBNET[floorEntry.getValue().getCidr()]);
                         denyRules.replace(subnet.getStartIpLong(), subnet);
                     } else {
+                        numDenyIps.addAndGet(IpUtils.NUM_SUBNET[subnet.getCidr()]);
                         denyRules.put(subnet.getStartIpLong(), subnet);
                     }
                 }

--- a/src/main/java/com/wynnn/ipfilter/utils/IpUtils.java
+++ b/src/main/java/com/wynnn/ipfilter/utils/IpUtils.java
@@ -14,6 +14,17 @@ public class IpUtils {
         return IP_PATTERN.matcher(ipAddress).matches();
     }
 
+    public static final long[] NUM_SUBNET = initNumSubnet();
+
+    private static long[] initNumSubnet() {
+        long[] numSubnet = new long[33];
+        numSubnet[32] = 1;
+        for (int i = 31; i >= 0; i--) {
+            numSubnet[i] = 2 * numSubnet[i + 1];
+        }
+        return numSubnet;
+    }
+
     public static long ipToLong(String ipAddress) {
         long result = 0;
 

--- a/src/main/resources-local/application.yml
+++ b/src/main/resources-local/application.yml
@@ -1,7 +1,6 @@
 spring:
   profiles:
     active: local
----
 ip-filter:
   deny:
     - 10.0.0.0/8

--- a/src/test/java/com/wynnn/ipfilter/config/IpFilterConfigurationTest.java
+++ b/src/test/java/com/wynnn/ipfilter/config/IpFilterConfigurationTest.java
@@ -23,7 +23,9 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @Slf4j
 public class IpFilterConfigurationTest {
@@ -191,5 +193,15 @@ public class IpFilterConfigurationTest {
         assertAll("test if deny rules are nested, then aggregate (even if different mask)",
                 () -> assertEquals(3, deny.size()),
                 () -> assertAll(executables));
+    }
+
+    @Test
+    void test_setDeny_if_exceed_max_count_then_stop_to_set() {
+        String[] denyRules = {"10.0.0.0/8", "11.0.0.0/8", "12.0.0.0/8", "13.0.0.0/8"};
+        ipFilterConfiguration.setDeny(Arrays.asList(denyRules));
+        TreeMap<Long, Ipv4Subnet> deny = ipFilterConfiguration.getDeny();
+        assertAll("test if exceed max count of deny IPs (30 million) then stop to set",
+                () -> assertEquals(2, deny.size()),
+                () -> assertEquals(IpUtils.ipToLong("11.0.0.0"), deny.lastEntry().getKey()));
     }
 }

--- a/src/test/java/com/wynnn/ipfilter/utils/IpUtilsTest.java
+++ b/src/test/java/com/wynnn/ipfilter/utils/IpUtilsTest.java
@@ -45,4 +45,12 @@ class IpUtilsTest {
             assertEquals(Long.parseLong(entry.getValue()[4]), IpUtils.calcEndIpInSubnet(Long.parseLong(entry.getValue()[0]), Integer.parseInt(entry.getValue()[2])));
         }
     }
+
+    @Test
+    void test_calcNumSubnet() {
+        assertEquals(4294967296L, IpUtils.NUM_SUBNET[0]);
+        assertEquals(2147483648L, IpUtils.NUM_SUBNET[1]);
+        assertEquals(256L, IpUtils.NUM_SUBNET[24]);
+        assertEquals(1, IpUtils.NUM_SUBNET[32]);
+    }
 }


### PR DESCRIPTION
* deny IP 등록 개수 제한
  * 최대 3000만개이나, subnet 을 더하여 조금 넘는 IP가 있는 경우 허용함
    - ex. 기존에 등록되어있는 IP 개수가 2999만999개인 경우 다음에 오는 IP subnet rule 이 /27 이여도 허용함.
    - 순차로 property file 을 load 하고, 3000만개가 넘어갈 경우 warning 으로 로깅하고 app 은 시작하므로, property file 순서대로 load 할 필요가 있습니다. 이에 IP subnet rule 이 3000만개를 조금 초과하더라도 허용했습니다.
    - 3000 만개만 등록 제한하는 규칙이 우선할 경우, property file 의 IP rule 순서를 변경하여 3000만개까지만 등록하거나, 3000만개 이상인 경우 application start 실패와 같은 처리가 필요합니다.

resolve #4