### PR TITLE
#20 subnets load 시 정렬 후 treeMap 에 저장토록 수정

### DIFF
--- a/src/test/java/com/wynnn/ipfilter/config/IpFilterConfigurationTest.java
+++ b/src/test/java/com/wynnn/ipfilter/config/IpFilterConfigurationTest.java
@@ -204,4 +204,15 @@ public class IpFilterConfigurationTest {
                 () -> assertEquals(2, deny.size()),
                 () -> assertEquals(IpUtils.ipToLong("11.0.0.0"), deny.lastEntry().getKey()));
     }
+
+    @Test
+    void test_setDeny_if_nested() {
+        String[] denyRules = {"10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32", "10.0.0.4/8"};
+        ipFilterConfiguration.setDeny(Arrays.asList(denyRules));
+        TreeMap<Long, Ipv4Subnet> deny = ipFilterConfiguration.getDeny();
+        log.debug(">>>>>>>>> {}", deny);
+        assertAll("test if exceed max count of deny IPs (30 million) then stop to set",
+                () -> assertEquals(1, deny.size()),
+                () -> assertEquals(IpUtils.ipToLong("10.0.0.0"), deny.lastEntry().getKey()));
+    }
 }


### PR DESCRIPTION
property load 시 subnet 의 sort 후 treeMap 에 저장하도록 수정
PR #7 에서 treeMap 으로 변환 시 과도하게 중첩 제거하는 부분 삭제하도록 수정했었으나,
해당 부분에 버그가 존재하여, 다시 정렬하는 과정 추가함
* 버그에 대한 TC 추가
